### PR TITLE
🔒 Move JWT token from localStorage to HttpOnly cookie

### DIFF
--- a/acts-connect-backend/src/main/java/com/connect/acts/ActsConnectBackend/controller/AuthController.java
+++ b/acts-connect-backend/src/main/java/com/connect/acts/ActsConnectBackend/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.connect.acts.ActsConnectBackend.dto.LoginRequest;
 import com.connect.acts.ActsConnectBackend.dto.RegisterRequest;
 import com.connect.acts.ActsConnectBackend.dto.UserResponse;
 import com.connect.acts.ActsConnectBackend.service.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,15 +30,47 @@ public class AuthController {
 
   //public method login
   @PostMapping("/login")
-  public ResponseEntity<UserResponse> login(@RequestBody @Valid LoginRequest loginRequest) {
+  public ResponseEntity<UserResponse> login(@RequestBody @Valid LoginRequest loginRequest, HttpServletResponse httpResponse) {
     UserResponse response = authService.loginUser(loginRequest);
+
+    if (response.getStatus() == 200 && response.getJwtToken() != null) {
+      Cookie cookie = new Cookie("jwt", response.getJwtToken());
+      cookie.setHttpOnly(true);
+      cookie.setPath("/");
+      cookie.setMaxAge(24 * 60 * 60); // 1 day
+      httpResponse.addCookie(cookie);
+      response.setJwtToken(null);
+    }
+
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
   //public method register
   @PostMapping("/register")
-  public ResponseEntity<UserResponse> register(@RequestBody @Valid RegisterRequest registerRequest) {
+  public ResponseEntity<UserResponse> register(@RequestBody @Valid RegisterRequest registerRequest, HttpServletResponse httpResponse) {
     UserResponse response = authService.registerUser(registerRequest);
+
+    if (response.getStatus() == 201 && response.getJwtToken() != null) {
+      Cookie cookie = new Cookie("jwt", response.getJwtToken());
+      cookie.setHttpOnly(true);
+      cookie.setPath("/");
+      cookie.setMaxAge(24 * 60 * 60); // 1 day
+      httpResponse.addCookie(cookie);
+      response.setJwtToken(null);
+    }
+
     return new ResponseEntity<>(response, HttpStatus.CREATED);
+  }
+
+  //public method logout
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(HttpServletResponse httpResponse) {
+    Cookie cookie = new Cookie("jwt", null);
+    cookie.setHttpOnly(true);
+    cookie.setPath("/");
+    cookie.setMaxAge(0); // This deletes the cookie
+    httpResponse.addCookie(cookie);
+
+    return ResponseEntity.ok().build();
   }
 }

--- a/acts-connect-backend/src/main/java/com/connect/acts/ActsConnectBackend/security/JwtAuthenticationFilter.java
+++ b/acts-connect-backend/src/main/java/com/connect/acts/ActsConnectBackend/security/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import com.connect.acts.ActsConnectBackend.service.UserService;
 import com.connect.acts.ActsConnectBackend.utils.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -29,13 +30,34 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-    final String authHeader = request.getHeader("Authorization");
     String email = null;
     String jwtToken = null;
 
-    if (authHeader != null && authHeader.startsWith("Bearer ")) {
-      jwtToken = authHeader.substring(7);
-      email = jwtUtil.extractEmail(jwtToken);
+    // First try to get token from cookies
+    if (request.getCookies() != null) {
+      for (Cookie cookie : request.getCookies()) {
+        if ("jwt".equals(cookie.getName())) {
+          jwtToken = cookie.getValue();
+          break;
+        }
+      }
+    }
+
+    // Fallback to Authorization header if not found in cookies
+    if (jwtToken == null) {
+      final String authHeader = request.getHeader("Authorization");
+      if (authHeader != null && authHeader.startsWith("Bearer ")) {
+        jwtToken = authHeader.substring(7);
+      }
+    }
+
+    if (jwtToken != null) {
+      try {
+        email = jwtUtil.extractEmail(jwtToken);
+      } catch (Exception e) {
+        // Log invalid token
+        logger.error("Error extracting email from JWT token: " + e.getMessage());
+      }
     }
 
     if (email != null && jwtUtil.validateToken(jwtToken, email) && SecurityContextHolder.getContext().getAuthentication() == null) {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -26,11 +26,10 @@ function App() {
   const {auth}=useSelector(store=>store)
 
   useEffect(()=>{
-    const jwt=localStorage.getItem("jwt")
-    if(jwt){
-      dispatch(getUserProfile(jwt))
-    }
-  },[auth.jwt])
+    // Always attempt to fetch the user profile on load.
+    // The backend will reject the request if the HttpOnly cookie is missing or invalid.
+    dispatch(getUserProfile())
+  },[dispatch])
 
   return (
     <ThemeProvider theme={darkTheme}>

--- a/frontend/src/Redux/Auth/auth.action.js
+++ b/frontend/src/Redux/Auth/auth.action.js
@@ -31,23 +31,13 @@ import {
 import { API_BASE_URL, api } from "../../config/api.js";
 import { GET_PROFILE_FAILURE } from "./auth.actionType.js";
 
-
-
-
-
-
-
-
 export const loginUser = (loginData) => async (dispatch) => {
   dispatch({type:LOGIN_REQUEST});
   try {
-    const response = await axios.post(`${API_BASE_URL}/auth/signin`, loginData.data);
+    const response = await axios.post(`${API_BASE_URL}/api/auth/login`, loginData.data, { withCredentials: true });
     const user = response.data;
     console.log("login user -: ", user);
-    if (user.jwt) {
-      localStorage.setItem("jwt", user.jwt);
-      loginData.navigate("/")
-    }
+    loginData.navigate("/");
     dispatch({type:LOGIN_SUCCESS,payload:user});
   } catch (error) {
     console.log("error ",error)
@@ -55,32 +45,12 @@ export const loginUser = (loginData) => async (dispatch) => {
   }
 };
 
-// export const loginWithGoogleAction = (data) => async (dispatch) => {
-//   dispatch({type:GOOGLE_LOGIN_REQUEST});
-//   try {
-//     const response = await axios.post(`${API_BASE_URL}/auth/signin/google`, data);
-//     const user = response.data;
-//     console.log("login with google user -: ", user);
-//     if (user.jwt) {
-//       localStorage.setItem("jwt", user.jwt);
-//     }
-//     dispatch({type:GOOGLE_LOGIN_SUCCESS,payload:user.jwt});
-//   } catch (error) {
-//     dispatch({type:GOOGLE_LOGIN_FAILURE, payload: error.message || "An error occurred during login."});
-//   }
-// };
-
-// /signin/google
-
 export const registerUser = (userData) => async (dispatch) => {
   dispatch({type:REGISTER_REQUEST});
   try {
-    const response = await axios.post(`${API_BASE_URL}/auth/signup`, userData);
+    const response = await axios.post(`${API_BASE_URL}/api/auth/register`, userData, { withCredentials: true });
     const user = response.data;
     console.log("created user - : ", user);
-    if (user.jwt) {
-      localStorage.setItem("jwt", user.jwt);
-    }
     dispatch({type:REGISTER_SUCCESS,payload:user});
   } catch (error) {
     dispatch(
@@ -89,15 +59,10 @@ export const registerUser = (userData) => async (dispatch) => {
   }
 };
 
-export const getUserProfile = (jwt) => async (dispatch) => {
+export const getUserProfile = () => async (dispatch) => {
   dispatch({type:GET_PROFILE_REUEST});
   try {
-    const response = await axios.get(`${API_BASE_URL}/api/users/profile`,{
-      headers:{
-        "Authorization":`Bearer ${jwt}`,
-
-      }
-    });
+    const response = await axios.get(`${API_BASE_URL}/api/users/profile`, { withCredentials: true });
     const user = response.data;
     console.log("login user -: ", user);
    
@@ -198,8 +163,12 @@ export const resetPassword = (reqData) => async (dispatch) => {
   }
 };
 
-export const logout = (navigate) => (dispatch) => {
-  // navigate("/")
-  localStorage.removeItem("jwt");
-  dispatch({ type: LOGOUT, payload: null });
+export const logout = (navigate) => async (dispatch) => {
+  try {
+    await axios.post(`${API_BASE_URL}/api/auth/logout`, {}, { withCredentials: true });
+    dispatch({ type: LOGOUT, payload: null });
+  } catch (error) {
+    console.log("error during logout", error);
+    dispatch({ type: LOGOUT, payload: null }); // Still clear frontend state
+  }
 };

--- a/frontend/src/components/TokenExpiredHandler.jsx
+++ b/frontend/src/components/TokenExpiredHandler.jsx
@@ -1,26 +1,44 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { logout } from '../Redux/Auth/auth.action';
+import axios from 'axios';
+import { api } from '../config/api';
 
-// Checks JWT expiry and logs out if expired
+// Sets up an Axios interceptor to handle 401 Unauthorized responses
 const TokenExpiredHandler = () => {
   const dispatch = useDispatch();
+
   useEffect(() => {
-    const checkToken = () => {
-      const token = localStorage.getItem('jwt');
-      if (!token) return;
-      try {
-        const payload = JSON.parse(atob(token.split('.')[1]));
-        if (payload.exp && Date.now() >= payload.exp * 1000) {
+    const interceptor = axios.interceptors.response.use(
+      (response) => response,
+      (error) => {
+        if (error.response && error.response.status === 401) {
+          // Token is likely expired or invalid
           dispatch(logout());
-          window.location.href = '/login';
+          window.location.href = '/';
         }
-      } catch (e) {}
+        return Promise.reject(error);
+      }
+    );
+
+    const apiInterceptor = api.interceptors.response.use(
+      (response) => response,
+      (error) => {
+        if (error.response && error.response.status === 401) {
+          // Token is likely expired or invalid
+          dispatch(logout());
+          window.location.href = '/';
+        }
+        return Promise.reject(error);
+      }
+    );
+
+    return () => {
+      axios.interceptors.response.eject(interceptor);
+      api.interceptors.response.eject(apiInterceptor);
     };
-    checkToken();
-    const interval = setInterval(checkToken, 60000); // check every minute
-    return () => clearInterval(interval);
   }, [dispatch]);
+
   return null;
 };
 

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,29 +1,24 @@
 import axios from "axios";
 export const API_BASE_URL = 'http://localhost:5454';
 
-// Axios instance without Authorization header
+// Axios instance configured to send cookies
 export const api = axios.create({
   baseURL: API_BASE_URL,
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
 });
 
-// Helper to get latest JWT token
-export function getAuthHeaders() {
-  const jwtToken = localStorage.getItem("jwt");
-  return jwtToken ? { Authorization: `Bearer ${jwtToken}` } : {};
-}
-
 // User-related API calls matching backend endpoints
 export const userApi = {
-  getPosts: () => api.get('/api/user/posts', { headers: getAuthHeaders() }),
-  createPost: (data) => api.post('/api/user/post/create', data, { headers: getAuthHeaders() }),
-  editPost: (postId, data) => api.post(`/api/user/post/edit/${postId}`, data, { headers: getAuthHeaders() }),
-  deletePost: (postId) => api.delete(`/api/user/post/delete/${postId}`, { headers: getAuthHeaders() }),
-  followUser: (userId) => api.post(`/api/user/follow/${userId}`, {}, { headers: getAuthHeaders() }),
-  unfollowUser: (userId) => api.post(`/api/user/unfollow/${userId}`, {}, { headers: getAuthHeaders() }),
-  createComment: (data) => api.post('/api/user/comment/create', data, { headers: getAuthHeaders() }),
-  searchUsers: (searchData) => api.post('/api/user/search', searchData, { headers: getAuthHeaders() }),
-  getUser: (id) => api.get(`/api/user/${id}`, { headers: getAuthHeaders() }),
+  getPosts: () => api.get('/api/user/posts'),
+  createPost: (data) => api.post('/api/user/post/create', data),
+  editPost: (postId, data) => api.post(`/api/user/post/edit/${postId}`, data),
+  deletePost: (postId) => api.delete(`/api/user/post/delete/${postId}`),
+  followUser: (userId) => api.post(`/api/user/follow/${userId}`, {}),
+  unfollowUser: (userId) => api.post(`/api/user/unfollow/${userId}`, {}),
+  createComment: (data) => api.post('/api/user/comment/create', data),
+  searchUsers: (searchData) => api.post('/api/user/search', searchData),
+  getUser: (id) => api.get(`/api/user/${id}`),
 };


### PR DESCRIPTION
🎯 What: JWT token was being stored in localStorage, making it vulnerable to Cross-Site Scripting (XSS) attacks.
⚠️ Risk: If an attacker executes malicious JavaScript on the page, they could steal the JWT from localStorage and impersonate the user.
🛡️ Solution: Moved the JWT to an HttpOnly cookie so it cannot be accessed via JavaScript. Updated the frontend to rely on Axios to automatically send the cookie with API requests instead of explicitly attaching an Authorization header. Also replaced frontend expiration checks with an Axios interceptor that handles 401 Unauthorized errors.

---
*PR created automatically by Jules for task [1432269404075833108](https://jules.google.com/task/1432269404075833108) started by @shreyashjagtap157*