### PR TITLE
Fix auto-generated constructor stub in PostException

### DIFF
--- a/ACTS Connect/ActsConnectDemo/src/main/java/com/actsconnect/exception/PostException.java
+++ b/ACTS Connect/ActsConnectDemo/src/main/java/com/actsconnect/exception/PostException.java
@@ -1,0 +1,13 @@
+package com.actsconnect.exception;
+
+public class PostException extends Exception {
+
+	public PostException() {
+		super();
+	}
+
+	public PostException(String message) {
+		super(message);
+	}
+
+}


### PR DESCRIPTION
- Extracted PostException.java from the zip archive.
- Replaced the auto-generated TODO comment in the empty constructor with a proper call to `super()`.

---
*PR created automatically by Jules for task [2649430149894278246](https://jules.google.com/task/2649430149894278246) started by @shreyashjagtap157*