### PR TITLE
Fix Auto-Generated Constructor Stub in ChatException

### DIFF
--- a/acts-connect-backend/src/main/java/com/actsconnect/exception/ChatException.java
+++ b/acts-connect-backend/src/main/java/com/actsconnect/exception/ChatException.java
@@ -1,0 +1,16 @@
+package com.actsconnect.exception;
+
+public class ChatException extends Exception {
+
+	public ChatException() {
+		super();
+	}
+
+	public ChatException(String message) {
+		super(message);
+	}
+
+	public ChatException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}


### PR DESCRIPTION
Removed the auto-generated constructor stub comment from the `ChatException` class as requested. Additionally added the standard no-arg and standard Throwable constructors for completeness.

---
*PR created automatically by Jules for task [2697092587080091489](https://jules.google.com/task/2697092587080091489) started by @shreyashjagtap157*