### PR TITLE
feat: Add likePost functionality

### DIFF
--- a/acts-connect-backend/src/main/java/com/connect/acts/ActsConnectBackend/controller/UserController.java
+++ b/acts-connect-backend/src/main/java/com/connect/acts/ActsConnectBackend/controller/UserController.java
@@ -250,6 +250,27 @@ public class UserController {
         return CompletableFuture.completedFuture(getUser(id));
     }
 
+
+    @PostMapping("/post/like/{postId}")
+    public ResponseEntity<ApiResponse<PostDTO>> likePost(@RequestHeader("Authorization") String token, @PathVariable UUID postId) {
+        String email = extractEmailFromToken(token);
+        User user = userService.findByEmail(email);
+        PostDTO updatedPost = postService.likePost(user, postId);
+        if (updatedPost == null) {
+            logger.warn("Post not found for like: {}", postId);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error("Post not found", null));
+        }
+        return ResponseEntity.ok(ApiResponse.success("Successfully Liked/Unliked!", updatedPost));
+    }
+
+    // Asynchronous version for multithreaded processing
+    @Async
+    @PostMapping("/post/like/{postId}/async")
+    public CompletableFuture<ResponseEntity<ApiResponse<PostDTO>>> likePostAsync(@RequestHeader("Authorization") String token, @PathVariable UUID postId) {
+        return CompletableFuture.completedFuture(likePost(token, postId));
+    }
+
     private String extractEmailFromToken(String token) {
         if (token != null && token.startsWith("Bearer ")) {
             token = token.substring(7);

--- a/acts-connect-backend/src/main/java/com/connect/acts/ActsConnectBackend/service/PostService.java
+++ b/acts-connect-backend/src/main/java/com/connect/acts/ActsConnectBackend/service/PostService.java
@@ -91,4 +91,23 @@ public class PostService {
   }
 
 
+
+  public PostDTO likePost(User user, UUID postId) {
+    if (user == null || postId == null) {
+      return null;
+    }
+    Optional<Post> postOptional = postRepo.findById(postId);
+    if (postOptional.isPresent()) {
+      Post post = postOptional.get();
+      if (!post.getLikedByUsers().contains(user)) {
+        post.getLikedByUsers().add(user);
+      } else {
+        post.getLikedByUsers().remove(user);
+      }
+      post = postRepo.save(post);
+      return new PostDTO(post.getId(), post.getTitle(), post.getContent(), post.isDummy(), post.getCreatedAt(), post.getUpdatedAt(), post.getUser().getId(), post.getUser().getName());
+    }
+    return null;
+  }
+
 }


### PR DESCRIPTION
Added `likePost` functionality to toggle a user's like on a post, resolving the `likePost` auto-generated stub request. Added associated synchronous and asynchronous REST API endpoints in the `UserController`.

---
*PR created automatically by Jules for task [17743158458774989612](https://jules.google.com/task/17743158458774989612) started by @shreyashjagtap157*