### PR TITLE
🔒 Fix sensitive information exposure in exception handler

### DIFF
--- a/acts-connect-backend/src/main/java/com/connect/acts/ActsConnectBackend/controller/GlobalExceptionHandler.java
+++ b/acts-connect-backend/src/main/java/com/connect/acts/ActsConnectBackend/controller/GlobalExceptionHandler.java
@@ -27,7 +27,7 @@ public class GlobalExceptionHandler {
     @ResponseBody
     public ApiResponse<String> handleIllegalArgumentException(IllegalArgumentException ex) {
         logger.warn("Illegal argument: {}", ex.getMessage());
-        return ApiResponse.error(ex.getMessage(), null);
+        return ApiResponse.error("Invalid argument provided", null);
     }
 
     @ExceptionHandler(Exception.class)

--- a/acts-connect-backend/src/test/java/com/connect/acts/ActsConnectBackend/controller/GlobalExceptionHandlerTest.java
+++ b/acts-connect-backend/src/test/java/com/connect/acts/ActsConnectBackend/controller/GlobalExceptionHandlerTest.java
@@ -1,0 +1,33 @@
+package com.connect.acts.ActsConnectBackend.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class GlobalExceptionHandlerTest {
+
+    private GlobalExceptionHandler exceptionHandler;
+
+    @BeforeEach
+    void setUp() {
+        exceptionHandler = new GlobalExceptionHandler();
+    }
+
+    @Test
+    void handleIllegalArgumentException_ShouldReturnGenericMessageAndObscureOriginalDetails() {
+        // Arrange
+        String sensitiveInternalDetails = "Sensitive user details: id=123, hash=abcdef";
+        IllegalArgumentException ex = new IllegalArgumentException(sensitiveInternalDetails);
+
+        // Act
+        ApiResponse<String> response = exceptionHandler.handleIllegalArgumentException(ex);
+
+        // Assert
+        assertFalse(response.isSuccess(), "Response should indicate failure");
+        assertEquals("Invalid argument provided", response.getMessage(), "Response message should be generic to prevent information leakage");
+        assertNull(response.getData(), "Data should be null");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `GlobalExceptionHandler` was directly exposing the internal exception message of `IllegalArgumentException` to clients in the API response.
⚠️ **Risk:** This could leak sensitive system details, user information, or internal architecture details if the exception message contains confidential data.
🛡️ **Solution:** Updated `handleIllegalArgumentException` to return a generic "Invalid argument provided" message to the client, while preserving the detailed original message in the server-side warning logs for debugging purposes. Added a unit test to verify this behavior.

---
*PR created automatically by Jules for task [15824392502498642765](https://jules.google.com/task/15824392502498642765) started by @shreyashjagtap157*