### PR TITLE
🔒 Fix: Replace System.err.println with SLF4J logger

### DIFF
--- a/acts-connect-backend/src/main/java/com/connect/acts/ActsConnectBackend/security/JwtAuthenticationEntryPoint.java
+++ b/acts-connect-backend/src/main/java/com/connect/acts/ActsConnectBackend/security/JwtAuthenticationEntryPoint.java
@@ -3,6 +3,8 @@ package com.connect.acts.ActsConnectBackend.security;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -11,10 +13,13 @@ import java.io.IOException;
 
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
-  @Override
-  public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-    // Optionally log unauthorized access
-    System.err.println("Unauthorized access attempt: " + authException.getMessage());
-    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
-  }
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationEntryPoint.class);
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        // Optionally log unauthorized access
+        logger.warn("Unauthorized access attempt: {}", authException.getMessage());
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
 }

--- a/acts-connect-backend/src/test/java/com/connect/acts/ActsConnectBackend/security/JwtAuthenticationEntryPointTest.java
+++ b/acts-connect-backend/src/test/java/com/connect/acts/ActsConnectBackend/security/JwtAuthenticationEntryPointTest.java
@@ -1,0 +1,44 @@
+package com.connect.acts.ActsConnectBackend.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.AuthenticationException;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class JwtAuthenticationEntryPointTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private AuthenticationException authException;
+
+    @InjectMocks
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Test
+    void commence_ShouldSetUnauthorizedStatus_WhenCalled() throws IOException, ServletException {
+        // Arrange
+        when(authException.getMessage()).thenReturn("Test error message");
+
+        // Act
+        jwtAuthenticationEntryPoint.commence(request, response, authException);
+
+        // Assert
+        verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+}

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,10 @@
+🔒 Fix: Replace System.err.println with SLF4J logger
+
+🎯 **What:** The vulnerability fixed
+In JwtAuthenticationEntryPoint, unauthorized access attempts were being logged using System.err.println instead of the standard SLF4J logger.
+
+⚠️ **Risk:** The potential impact if left unfixed
+Using standard out/error for logging is insecure and inefficient. It bypasses the configured logging framework (SLF4J/Logback), which means logs might be lost, unformatted, or not properly rotated, potentially missing important security auditing trails for unauthorized access. It also risks exposing sensitive data if it isn't properly managed or filtered by the logging setup.
+
+🛡️ **Solution:** How the fix addresses the vulnerability
+Replaced System.err.println with an SLF4J Logger.warn call. This ensures that unauthorized access attempts are consistently recorded using the application's configured logging pipeline, matching standard enterprise security practices.


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
In JwtAuthenticationEntryPoint, unauthorized access attempts were being logged using System.err.println instead of the standard SLF4J logger.

⚠️ **Risk:** The potential impact if left unfixed
Using standard out/error for logging is insecure and inefficient. It bypasses the configured logging framework (SLF4J/Logback), which means logs might be lost, unformatted, or not properly rotated, potentially missing important security auditing trails for unauthorized access. It also risks exposing sensitive data if it isn't properly managed or filtered by the logging setup.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced System.err.println with an SLF4J Logger.warn call. This ensures that unauthorized access attempts are consistently recorded using the application's configured logging pipeline, matching standard enterprise security practices.

---
*PR created automatically by Jules for task [16980538828439934165](https://jules.google.com/task/16980538828439934165) started by @shreyashjagtap157*