### PR TITLE
fix: remove auto-generated constructor stub in MessageException

### DIFF
--- a/acts-connect-backend/src/main/java/com/actsconnect/exception/MessageException.java
+++ b/acts-connect-backend/src/main/java/com/actsconnect/exception/MessageException.java
@@ -1,0 +1,8 @@
+package com.actsconnect.exception;
+
+public class MessageException extends Exception {
+
+    public MessageException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Removed the unused comment in the auto-generated code.

---
*PR created automatically by Jules for task [8513856493921882391](https://jules.google.com/task/8513856493921882391) started by @shreyashjagtap157*